### PR TITLE
refactor: apply common Rust semantics

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -41,7 +41,7 @@ pub fn validate_args(mut args: Args) -> Result<Args, String> {
     }
 
     if args.platforms.is_none() {
-        args.platforms = Option::from(Vec::from([Platform::Web, Platform::Modern]));
+        args.platforms = Some(vec![Platform::Web, Platform::Modern]);
     }
 
     if args.output.is_none() {
@@ -51,10 +51,10 @@ pub fn validate_args(mut args: Args) -> Result<Args, String> {
         output_path.push(cwd);
         output_path.push("output");
 
-        args.output = Option::from(output_path);
+        args.output = Some(output_path);
     }
 
-    return Ok(args);
+    Ok(args)
 }
 
 #[cfg(test)]
@@ -65,22 +65,22 @@ mod tests {
     fn test_assign_default_platforms() {
         let args = Args {
             source: PathBuf::from("samples/sample.svg"),
-            platforms: Option::None,
-            output: Option::from(PathBuf::from("here")),
+            platforms: None,
+            output: Some(PathBuf::from("here")),
             template: false,
         };
         let result = validate_args(args);
 
-        assert_eq!(result.is_err(), false);
-        assert_eq!(result.unwrap().platforms.unwrap(), Vec::from([Platform::Web, Platform::Modern]));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().platforms.unwrap(), vec![Platform::Web, Platform::Modern]);
     }
 
     #[test]
     fn test_assign_default_output() {
         let args = Args {
             source: PathBuf::from("samples/sample.svg"),
-            platforms: Option::from(Vec::from([Platform::Web, Platform::Modern])),
-            output: Option::None,
+            platforms: Some(vec![Platform::Web, Platform::Modern]),
+            output: None,
             template: false,
         };
         let result = validate_args(args);
@@ -91,7 +91,7 @@ mod tests {
         path.push(cwd);
         path.push("output");
 
-        assert_eq!(result.is_err(), false);
+        assert!(result.is_ok());
         assert_eq!(result.unwrap().output.unwrap().to_str(), path.to_str());
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -94,8 +94,8 @@ mod tests {
         let has_svg = result.iter().find(|x| x.name == "icon.svg");
         let has_else = result.iter().find(|x| x.name != "icon.svg");
 
-        assert_eq!(has_svg.is_some(), true);
-        assert_eq!(has_else.is_some(), false);
+        assert!(has_svg.is_some());
+        assert!(has_else.is_none());
     }
 
     #[test]
@@ -109,9 +109,9 @@ mod tests {
         let has_ico = result.iter().find(|x| x.name == "favicon.ico");
         let has_apple = result.iter().find(|x| x.name == "apple_touch_icon.png");
 
-        assert_eq!(has_svg.is_some(), true);
-        assert_eq!(has_ico.is_some(), true);
-        assert_eq!(has_apple.is_some(), true);
+        assert!(has_svg.is_some());
+        assert!(has_ico.is_some());
+        assert!(has_apple.is_some());
     }
 
     #[test]
@@ -124,8 +124,8 @@ mod tests {
         let has_mq = result.iter().find(|x| x.name == "192.png");
         let has_hq = result.iter().find(|x| x.name == "512.png");
 
-        assert_eq!(has_mq.is_some(), true);
-        assert_eq!(has_hq.is_some(), true);
+        assert!(has_mq.is_some());
+        assert!(has_hq.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Overview

This pull request applies common Rust semantics to the code, mainly:

1. Replace `Vec::from` with initialized values with `vec![]` macro.
2. Replace `Option::from` with `Some()`.
3. Replace `Option::None` with `None`.